### PR TITLE
fix NoSuchElementException crash for offline PDFs

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -430,7 +430,13 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                     } catch(Exception ex) {
 
                     }
-                    return chain.proceed(chain.request());
+                    try {
+                    	return chain.proceed(chain.request());
+                	}
+                	catch(Exception ex) {
+                		throw new IOException();
+                	}
+                }
                 }
             });
 


### PR DESCRIPTION
Catches a NoSuchElementException exception which our version of okhttp can't handle and throws an IOException which it can